### PR TITLE
added content type to save methods

### DIFF
--- a/esawsfunctions/funk.py
+++ b/esawsfunctions/funk.py
@@ -62,7 +62,8 @@ def save_to_s3(bucket_name, output_file_name, output_data):
     :return: None
     """
     s3 = boto3.resource("s3", region_name="eu-west-2")
-    s3.Object(bucket_name, output_file_name).put(Body=output_data, ContentType='application/json')
+    s3.Object(bucket_name, output_file_name).put(Body=output_data,
+                                                 ContentType='application/json')
 
 
 def write_dataframe_to_csv(dataframe, bucket_name, filename):
@@ -76,7 +77,8 @@ def write_dataframe_to_csv(dataframe, bucket_name, filename):
     csv_buffer = StringIO()
     dataframe.to_csv(csv_buffer, sep=",", index=False)
     s3_resource = boto3.resource("s3")
-    s3_resource.Object(bucket_name, filename).put(Body=csv_buffer.getvalue(), ContentType='text/plain')
+    s3_resource.Object(bucket_name, filename).put(Body=csv_buffer.getvalue(),
+                                                  ContentType='text/plain')
 
 
 def send_sqs_message(queue_url, message, output_message_id):

--- a/esawsfunctions/funk.py
+++ b/esawsfunctions/funk.py
@@ -54,7 +54,7 @@ def save_to_s3(bucket_name, output_file_name, output_data):
     :return: None
     """
     s3 = boto3.resource("s3", region_name="eu-west-2")
-    s3.Object(bucket_name, output_file_name).put(Body=output_data)
+    s3.Object(bucket_name, output_file_name).put(Body=output_data, ContentType='application/json')
 
 
 def write_dataframe_to_csv(dataframe, bucket_name, filename):
@@ -68,7 +68,7 @@ def write_dataframe_to_csv(dataframe, bucket_name, filename):
     csv_buffer = StringIO()
     dataframe.to_csv(csv_buffer, sep=",", index=False)
     s3_resource = boto3.resource("s3")
-    s3_resource.Object(bucket_name, filename).put(Body=csv_buffer.getvalue())
+    s3_resource.Object(bucket_name, filename).put(Body=csv_buffer.getvalue(), ContentType='text/plain')
 
 
 def send_sqs_message(queue_url, message, output_message_id):

--- a/esawsfunctions/funk.py
+++ b/esawsfunctions/funk.py
@@ -17,6 +17,14 @@ class NoDataInQueueError(Exception):
     pass
 
 
+class MethodFailure(Exception):
+    """
+    Custom exception signifying that the method has encountered an exception.
+    """
+    def __init__(self, message):
+        self.error_message = message
+
+
 def read_from_s3(bucket_name, file_name):
     """
     Given the name of the bucket and the filename(key), this function will


### PR DESCRIPTION
Kris pointed out at some stage that because we dont specify content-type when saving to s3, it infers it badly. Meaning that if we ever want to view a file we have to download it. This fixes that by specifying the content type, allowing the files to be viewed in the browser
