### PR TITLE
Lu4927 lambdafail

### DIFF
--- a/TestGenericLibrary.md
+++ b/TestGenericLibrary.md
@@ -7,11 +7,11 @@
 [General Error](#generalerror)<br>
 [Incomplete Read Error](#incompletereaderror)<br>
 [Key Error](#keyerror)<br>
-[Method Error](#methoderror)<br>
 [Replacement Get Dataframe](#replacementgetdataframe)<br>
 [Replacement Save Data](#replacementsavedata)<br>
 [Upload Files](#uploadfiles)<br>
 [Value Error](#valueerror)<br>
+[Wrangler Method Error](#methoderror)<br>
 
 ## Functions
 ### Client Error <a name='clienterror'>
@@ -19,6 +19,11 @@ Function to trigger a client error in a lambda. By not mocking any of the boto3 
 
 If used on a method, data is part of the runtime_variables, so the file_name is loaded in
 and the file added to the runtime_variables dictionary.
+
+#### Variants:
+wrangler_client_error()<br>
+method_client_error()
+
 #### Parameters:
 lambda_function: Lambda function to test - Type: Function<br>
 runtime_variables: Runtime variables to send to function - Type: Dict<br>
@@ -29,7 +34,10 @@ file_name: Name of file to retrieve data from - Type: String<br>
 Test Pass/Fail<br>
 #### Usage:
 ```
-test_generic_library.client_error(which_lambda, which_runtime_variables, which_environment_variables, which_data)
+test_generic_library.method_client_error(which_lambda, which_runtime_variables, which_environment_variables, which_data)
+
+test_generic_library.wrangler_client_error(which_lambda, which_runtime_variables, which_environment_variables, which_data)
+
 ```
 
 [Back to top](#top)
@@ -81,6 +89,10 @@ The variable 'mockable_function' defines the function in the lambda that will
 be mocked out. This should be something fairly early in the code (but still
 within try/except). e.g. "enrichment_wrangler.EnvironSchema"
 
+#### Variants:
+wrangler_general_error()<br>
+method_general_error()
+
 #### Parameters:
 lambda_function: Lambda function to test - Type: Function<br>
 runtime_variables: Runtime variables to send to function - Type: Dict<br>
@@ -92,8 +104,12 @@ Test Pass/Fail
 
 #### Usage:
 ```
-test_generic_library.general_error(which_lambda, which_runtime_variables,
+test_generic_library.method_general_error(which_lambda, which_runtime_variables,
                                            which_environment_variables, mockable_function)
+
+test_generic_library.wrangler_general_error(which_lambda, which_runtime_variables,
+                                           which_environment_variables, mockable_function)
+
 ```
 
 [Back to top](#top)
@@ -133,6 +149,10 @@ Function to trigger a key error in a given lambda.<br><bR>
 Makes use of an empty dict of runtime variables,<br>
 which triggers a key error once access is attempted.
 
+#### Variants:
+wrangler_value_error()<br>
+method_value_error()
+
 #### Parameters:
 lambda_function: Lambda function to test - Type: Function<br>
 environment_variables: Environment Vars to send to function - Type: Dict<br>
@@ -143,38 +163,15 @@ Test Pass/Fail
 
 #### Usage:
 ```
-test_generic_library.key_error(which_lambda, which_environment_variables, bad_runtime_variables)
+test_generic_library.wrangler_key_error(which_lambda, which_environment_variables, bad_runtime_variables)
+
+test_generic_library.method_key_error(which_lambda, which_environment_variables, bad_runtime_variables)
+
 ```
 
 [Back to top](#top)
 <hr>
 
-### Method Error <a name='methoderror'>
-Function to trigger a method error in a given function.<br><Br>
-
-Takes in a valid file(s) so that the function performs until after the lambda invoke.
-
-#### Parameters:
-lambda_function: Lambda function to test - Type: Function<br>
-runtime_variables: Runtime variables to send to function - Type: Dict<br>
-environment_variables: Environment Vars to send to function - Type: Dict<br>
-file_list: List of input files for the function - Type: List<br>
-wrangler_name: Wrangler that is being tested, used in mocking boto3. - Type: String
-
-#### Return:
-Test Pass/Fail
-
-#### Usage:
-```
-test_generic_library.method_error(lambda_wrangler_function,
-                                          wrangler_runtime_variables,
-                                          wrangler_environment_variables,
-                                          file_list,
-                                          "enrichment_wrangler")
-```
-
-[Back to top](#top)
-<hr>
 
 ### Replacement Get Dataframe <a name='replacementgetdataframe'>
 Function to replace the aws-functions.get_dataframe when performing tests.<br><Br>
@@ -252,6 +249,10 @@ Function to trigger a value error in a given function.<br><br>
 Does so by passing an empty list of environment variables
 to trigger an error with marshmallow.
 
+#### Variants:
+wrangler_value_error()<br>
+method_value_error()
+
 #### Parameters:
 lambda_function: Lambda function to test - Type: Function<br>
 runtime_variables: Runtime variables to send to function - Type: Dict<br>
@@ -262,7 +263,36 @@ Test Pass/Fail
 
 #### Usage:
 ```
-test_generic_library.value_error(which_lambda, bad_runtime_variables, bad_environment_variables)
+test_generic_library.method_value_error(which_lambda, bad_runtime_variables, bad_environment_variables)
+
+test_generic_library.wrangler_value_error(which_lambda, bad_runtime_variables, bad_environment_variables)
+```
+
+[Back to top](#top)
+<hr>
+
+### Wrangler Method Error <a name='methoderror'>
+Function to trigger a method error in a given function.<br><Br>
+
+Takes in a valid file(s) so that the function performs until after the lambda invoke.
+
+#### Parameters:
+lambda_function: Lambda function to test - Type: Function<br>
+runtime_variables: Runtime variables to send to function - Type: Dict<br>
+environment_variables: Environment Vars to send to function - Type: Dict<br>
+file_list: List of input files for the function - Type: List<br>
+wrangler_name: Wrangler that is being tested, used in mocking boto3. - Type: String
+
+#### Return:
+Test Pass/Fail
+
+#### Usage:
+```
+test_generic_library.wrangler_method_error(lambda_wrangler_function,
+                                          wrangler_runtime_variables,
+                                          wrangler_environment_variables,
+                                          file_list,
+                                          "enrichment_wrangler")
 ```
 
 [Back to top](#top)

--- a/TestModuleExample.md
+++ b/TestModuleExample.md
@@ -14,32 +14,32 @@ Note that for the generic tests to be used the runtime and evironment variables 
 ##########################################################################################
 
 
-@pytest.mark.parametrize(
-    "which_lambda,which_runtime_variables,which_environment_variables,which_data",
-    [
-        (lambda_method_function, method_runtime_variables,
-         method_environment_variables, "tests/fixtures/test_method_input.json"),
-        (lambda_wrangler_function, wrangler_runtime_variables,
-         wrangler_environment_variables, None)
-    ])
-def test_client_error(which_lambda, which_runtime_variables,
-                      which_environment_variables, which_data):
-    test_generic_library.client_error(which_lambda, which_runtime_variables,
-                                      which_environment_variables, which_data)
+def test_wrangler_client_error():
+    test_generic_library.wrangler_client_error(lambda_wrangler_function,
+                                               wrangler_runtime_variables,
+                                               wrangler_environment_variables,
+                                               None)
 
 
-@pytest.mark.parametrize(
-    "which_lambda,which_runtime_variables,which_environment_variables,mockable_function",
-    [
-        (lambda_method_function, method_runtime_variables,
-         method_environment_variables, "enrichment_method.EnvironSchema"),
-        (lambda_wrangler_function, wrangler_runtime_variables,
-         wrangler_environment_variables, "enrichment_wrangler.EnvironSchema")
-    ])
-def test_general_error(which_lambda, which_runtime_variables,
-                       which_environment_variables, mockable_function):
-    test_generic_library.general_error(which_lambda, which_runtime_variables,
-                                       which_environment_variables, mockable_function)
+def test_method_client_error():
+    test_generic_library.method_client_error(lambda_method_function,
+                                             method_runtime_variables,
+                                             method_environment_variables,
+                                             "tests/fixtures/test_method_input.json")
+
+
+def test_wrangler_general_error():
+    test_generic_library.wrangler_general_error(lambda_wrangler_function,
+                                                wrangler_runtime_variables,
+                                                wrangler_environment_variables,
+                                                "enrichment_wrangler.EnvironSchema")
+
+
+def test_method_general_error():
+    test_generic_library.method_general_error(lambda_method_function,
+                                              method_runtime_variables,
+                                              method_environment_variables,
+                                              "enrichment_method.EnvironSchema")
 
 
 @mock_s3
@@ -55,14 +55,12 @@ def test_incomplete_read_error(mock_s3_get):
                                                "enrichment_wrangler")
 
 
-@pytest.mark.parametrize(
-    "which_lambda,which_environment_variables",
-    [
-        (lambda_method_function, method_environment_variables),
-        (lambda_wrangler_function, wrangler_environment_variables)
-    ])
-def test_key_error(which_lambda, which_environment_variables):
-    test_generic_library.key_error(which_lambda, which_environment_variables)
+def test_wrangler_key_error():
+    test_generic_library.wrangler_key_error(lambda_wrangler_function, wrangler_environment_variables)
+
+
+def test_method_key_error():
+    test_generic_library.method_key_error(lambda_method_function, method_environment_variables)
 
 
 @mock_s3
@@ -71,18 +69,20 @@ def test_key_error(which_lambda, which_environment_variables):
 def test_method_error(mock_s3_get):
     file_list = ["test_wrangler_input.json"]
 
-    test_generic_library.method_error(lambda_wrangler_function,
+    test_generic_library.wrangler_method_error(lambda_wrangler_function,
                                       wrangler_runtime_variables,
                                       wrangler_environment_variables,
                                       file_list,
                                       "enrichment_wrangler")
 
 
-@pytest.mark.parametrize(
-    "which_lambda",
-    [lambda_method_function, lambda_wrangler_function])
-def test_value_error(which_lambda):
-    test_generic_library.value_error(which_lambda)
+def test_wrangler_value_error():
+    test_generic_library.wrangler_value_error(lambda_wrangler_function)
+
+
+def test_method_value_error():
+    test_generic_library.method_value_error(lambda_method_function)
+
 ```
 [Back to top](#top)
 <hr>

--- a/es_aws_functions/test_generic_library.py
+++ b/es_aws_functions/test_generic_library.py
@@ -15,7 +15,7 @@ class MockContext:
 bad_environment_variables = {}
 
 bad_runtime_variables = {
-    "RuntimeVariables": {}
+    "RuntimeVariables": {"run_id":"run_id"}
 }
 
 context_object = MockContext()

--- a/es_aws_functions/test_generic_library.py
+++ b/es_aws_functions/test_generic_library.py
@@ -15,13 +15,14 @@ class MockContext:
 bad_environment_variables = {}
 
 bad_runtime_variables = {
-    "RuntimeVariables": {"run_id":"run_id"}
+    "RuntimeVariables": {"run_id": "run_id"}
 }
 
 context_object = MockContext()
 
 
-def wrangler_client_error(lambda_function, runtime_variables, environment_variables, file_name):
+def wrangler_client_error(lambda_function, runtime_variables,
+                          environment_variables, file_name):
     """
     Function to trigger a client error in a wrangler.
     By not mocking any of the boto3 functions, once any are used in code they will
@@ -45,7 +46,8 @@ def wrangler_client_error(lambda_function, runtime_variables, environment_variab
         assert "AWS Error" in exc_info.value.error_message
 
 
-def method_client_error(lambda_function, runtime_variables, environment_variables, file_name):
+def method_client_error(lambda_function, runtime_variables,
+                        environment_variables, file_name):
     """
     Function to trigger a client error in a method.
     By not mocking any of the boto3 functions, once any are used in code they will
@@ -98,7 +100,7 @@ def create_client(client_type, region="eu-west-2"):
 
 
 def wrangler_general_error(lambda_function, runtime_variables,
-                  environment_variables, mockable_function):
+                           environment_variables, mockable_function):
     """
     Function to trigger a general error in a given wrangler.
 
@@ -122,7 +124,7 @@ def wrangler_general_error(lambda_function, runtime_variables,
 
 
 def method_general_error(lambda_function, runtime_variables,
-                  environment_variables, mockable_function):
+                         environment_variables, mockable_function):
     """
     Function to trigger a general error in a given method.
     The variable 'mockable_function' defines the function in the lambda that will
@@ -182,7 +184,7 @@ def incomplete_read_error(lambda_function, runtime_variables,
 
 
 def wrangler_key_error(lambda_function, environment_variables,
-              runtime_variables=bad_runtime_variables):
+                       runtime_variables=bad_runtime_variables):
     """
     Function to trigger a key error in a given wrangler.
 
@@ -202,7 +204,7 @@ def wrangler_key_error(lambda_function, environment_variables,
 
 
 def method_key_error(lambda_function, environment_variables,
-              runtime_variables=bad_runtime_variables):
+                     runtime_variables=bad_runtime_variables):
     """
     Function to trigger a key error in a given method.
     Makes use of an empty dict of runtime variables,
@@ -221,7 +223,7 @@ def method_key_error(lambda_function, environment_variables,
 
 
 def wrangler_method_error(lambda_function, runtime_variables,
-                 environment_variables, file_list, wrangler_name):
+                          environment_variables, file_list, wrangler_name):
     """
     Function to trigger a method error in a given function.
 
@@ -316,7 +318,7 @@ def upload_files(client, bucket_name, file_list):
 
 
 def wrangler_value_error(lambda_function, runtime_variables=bad_runtime_variables,
-                environment_variables=bad_environment_variables):
+                         environment_variables=bad_environment_variables):
     """
     Function to trigger a value error in a given wrangler.
 
@@ -335,7 +337,7 @@ def wrangler_value_error(lambda_function, runtime_variables=bad_runtime_variable
 
 
 def method_value_error(lambda_function, runtime_variables=bad_runtime_variables,
-                environment_variables=bad_environment_variables):
+                       environment_variables=bad_environment_variables):
     """
     Function to trigger a value error in a given method.
     Does so by passing an empty list of environment variables

--- a/es_aws_functions/test_generic_library.py
+++ b/es_aws_functions/test_generic_library.py
@@ -125,7 +125,6 @@ def method_general_error(lambda_function, runtime_variables,
                   environment_variables, mockable_function):
     """
     Function to trigger a general error in a given method.
-
     The variable 'mockable_function' defines the function in the lambda that will
     be mocked out. This should be something fairly early in the code (but still
     within try/except). e.g. "enrichment_wrangler.EnvironSchema"
@@ -140,9 +139,10 @@ def method_general_error(lambda_function, runtime_variables,
         mock_schema.side_effect = Exception("Failed To Log")
 
         with mock.patch.dict(lambda_function.os.environ, environment_variables):
-            with pytest.raises(exception_classes.LambdaFailure) as exc_info:
-                lambda_function.lambda_handler(runtime_variables, context_object)
-            assert "General Error" in exc_info.value.error_message
+            output = lambda_function.lambda_handler(runtime_variables, context_object)
+
+    assert 'error' in output.keys()
+    assert output["error"].__contains__("""General Error""")
 
 
 def incomplete_read_error(lambda_function, runtime_variables,


### PR DESCRIPTION
Unfortunately, because a methods sad path and a wranglers sad path are now different(one fires off an exception), we cant use the same test on each. So I have seperated out some of the tests to allow them to work.