### PR TITLE
Run id in file name

### DIFF
--- a/AWSFunctions.md
+++ b/AWSFunctions.md
@@ -22,7 +22,8 @@ error.
 
 #### Parameters:
 bucket_name: Name of the S3 bucket - Type: String <br>
-file_name: Name of the file - Type: String
+file_name: Name of the file - Type: String <br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Return:
 Success or error message - Type: String
@@ -47,7 +48,8 @@ Data is returned as a json string. To use as dataframe you will need to json.loa
 queue_url: The url of the queue to retrieve message from - Type: String<br>
 bucket_name: The default bucket name to use if no message from previous module - Type: String<br>
 key: The default file name to use if no message from the previous module - Type: String<br>
-incoming_message_group: The name of the message group from previous module - Type: String (example: enrichmentOut)<br>
+incoming_message_group: The name of the message group from previous module - Type: String (example: enrichmentOut <br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Returns:
 data: The data from s3 - Type: Json<br>
@@ -72,6 +74,7 @@ queue_url: The url of the queue to retrieve message from - Type: String<br>
 bucket_name: The default bucket name to use if no message from previous module - Type: String<br>
 key: The default file name to use if no message from the previous module - Type: String<br>
 incoming_message_group: The name of the message group from previous module - Type: String (example: enrichmentOut)<br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Returns:
 data: The data from s3 - Type: DataFrame<br>
@@ -132,7 +135,8 @@ return contents of a file. File is Dataframe format.
 
 #### Parameters:
 bucket_name: Name of the S3 bucket - Type: String <br>
-file_name: Name of the file - Type: String
+file_name: Name of the file - Type: String <br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Return:
 input_file: The JSON file in S3 - Type: String
@@ -150,7 +154,8 @@ return a file. File is JSON format.
 
 #### Parameters:
 bucket_name: Name of the S3 bucket - Type: String <br>
-file_name: Name of the file - Type: String
+file_name: Name of the file - Type: String <br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Return:
 input_file: The JSON file in S3 - Type: String
@@ -174,6 +179,7 @@ file_name: The name to give the file being saved - Type: String<br>
 data: The data to be saved - Type Json string<br>
 queue_url: The url of the queue to use in sending the file details - Type: String<br>
 message_id: The label of the message sent to sqs(Message_group_id, what module sent the message) - Type: String (example: enrichmentOut)<br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Return:
 Nothing
@@ -194,6 +200,7 @@ This function uploads a specified set of data to the s3 bucket under the given n
 bucket_name: Name of the bucket you wish to upload too - Type: String.<br>
 output_file_name: Name you want the file to be called on s3 - Type: String.<br>
 output_data: The data that you wish to upload to s3 - Type: JSON string. - Note, this must be string<br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Return:
 Nothing
@@ -274,6 +281,7 @@ This function takes a Dataframe and stores it in a specific bucket.<br>
 Dataframe: The Dataframe you wish to save - Type: Dataframe.<br>
 Bucket_name: Name of the bucket you wish to save the csv into - Type: String.<br>
 Output_data: Filename: The name given to the CSV - Type: String.<br>
+run_id: Optional, run id to be added as file name prefix - Type: String <br>
 
 #### Return:
 Nothing

--- a/es_aws_functions/aws_functions.py
+++ b/es_aws_functions/aws_functions.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 from es_aws_functions import exception_classes
 
 
-def delete_data(bucket_name, file_name):
+def delete_data(bucket_name, file_name, run_id = ""):
     """
     Deletes specified file from specified S3 bucket.
     Checks if file exists before deletion.
@@ -16,18 +16,23 @@ def delete_data(bucket_name, file_name):
 
     :param bucket_name: The name of the bucket containing the file - Type: String
     :param file_name: The name of the file being deleted - Type: String
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: Success or error message - Type: String
     """
     s3 = boto3.resource('s3', region_name='eu-west-2')
     try:
-        s3.Object(bucket_name, file_name).load()
-        s3.Object(bucket_name, file_name).delete()
+        full_file_name = file_name
+        if len(run_id) > 0:
+            full_file_name = run_id + "-" + file_name
+
+        s3.Object(bucket_name, full_file_name).load()
+        s3.Object(bucket_name, full_file_name).delete()
         return "Succesfully deleted file from S3 bucket."
     except ClientError:
         return "File does not exist in specified bucket!"
 
 
-def get_data(queue_url, bucket_name, key, incoming_message_group):
+def get_data(queue_url, bucket_name, key, incoming_message_group, run_id = ""):
     """
     Get data function recieves a message from an sqs queue,
     extracts the bucket and filename, then uses them to get the file from s3.
@@ -48,6 +53,7 @@ def get_data(queue_url, bucket_name, key, incoming_message_group):
     module - Type: String
     :param incoming_message_group: The name of the message group from previous
     module - Type: String
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return data: The data from s3 - Type: Json
     :return receipt_handle: The receipt_handle of the incoming message
     (used to delete old message) - Type: String
@@ -69,11 +75,12 @@ def get_data(queue_url, bucket_name, key, incoming_message_group):
         message = json.loads(message["Body"])
         bucket = message["bucket"]
         key = message["key"]
-    data = read_from_s3(bucket, key)
+        
+    data = read_from_s3(bucket, key, run_id)
     return data, receipt_handle
 
 
-def get_dataframe(queue_url, bucket_name, key, incoming_message_group):
+def get_dataframe(queue_url, bucket_name, key, incoming_message_group, run_id = ""):
     """
     Get data function recieves a message from an sqs queue,
     extracts the bucket and filename, then uses them to get the file from s3.
@@ -94,11 +101,13 @@ def get_dataframe(queue_url, bucket_name, key, incoming_message_group):
     module - Type: String
     :param incoming_message_group: The name of the message group from previous
     module - Type: String
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return data: The data from s3 - Type: DataFrame
     :return receipt_handle: The receipt_handle of the incoming message
     (used to delete old message) - Type: String
     """
-    data, receipt_handle = get_data(queue_url, bucket_name, key, incoming_message_group)
+    data, receipt_handle = get_data(queue_url, bucket_name, key, 
+                                    incoming_message_group, run_id)
     data = pd.read_json(data, dtype=False)
     return data, receipt_handle
 
@@ -145,12 +154,13 @@ def get_sqs_messages(sqs_queue_url, number_of_messages, incoming_message_group):
     return messages
 
 
-def read_dataframe_from_s3(bucket_name, file_name):
+def read_dataframe_from_s3(bucket_name, file_name, run_id = ""):
     """
     Given the name of the bucket and the filename(key), this function will
     return contents of a file. File is DataFrame format.
     :param bucket_name: Name of the S3 bucket - Type: String
     :param file_name: Name of the file - Type: String
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: input_file: The JSON file in S3 loaded into dataframe table - Type: DataFrame
     """
     input_file = read_from_s3(bucket_name, file_name)
@@ -158,22 +168,28 @@ def read_dataframe_from_s3(bucket_name, file_name):
     return pd.DataFrame(json_content)
 
 
-def read_from_s3(bucket_name, file_name):
+def read_from_s3(bucket_name, file_name, run_id = ""):
     """
     Given the name of the bucket and the filename(key), this function will
     return a file. File is JSON format.
     :param bucket_name: Name of the S3 bucket - Type: String
     :param file_name: Name of the file - Type: String
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: input_file: The JSON file in S3 - Type: String
     """
     s3 = boto3.resource("s3", region_name="eu-west-2")
-    s3_object = s3.Object(bucket_name, file_name)
+
+    full_file_name = file_name
+    if len(run_id) > 0:
+        full_file_name = run_id + "-" + file_name
+
+    s3_object = s3.Object(bucket_name, full_file_name)
     input_file = s3_object.get()["Body"].read().decode("UTF-8")
 
     return input_file
 
 
-def save_data(bucket_name, file_name, data, queue_url, message_id):
+def save_data(bucket_name, file_name, data, queue_url, message_id, run_id = ""):
     """
     Save data function stores data in s3 and passes the bucket & filename
     onto sqs queue. SQS only supports message length of 256k, so this function
@@ -188,23 +204,30 @@ def save_data(bucket_name, file_name, data, queue_url, message_id):
     :param message_id: The label of the message sent to sqs(Message_group_id,
     what module sent the message)
     - Type: String
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: Nothing
     """
-    save_to_s3(bucket_name, file_name, data)
+    save_to_s3(bucket_name, file_name, data, run_id)
     sqs_message = json.dumps({"bucket": bucket_name, "key": file_name})
     send_sqs_message(queue_url, sqs_message, message_id)
 
 
-def save_to_s3(bucket_name, output_file_name, output_data):
+def save_to_s3(bucket_name, output_file_name, output_data, run_id = ""):
     """
     This function uploads a specified set of data to the s3 bucket under the given name.
     :param bucket_name: Name of the bucket you wish to upload too - Type: String.
     :param output_file_name: Name you want the file to be called on s3 - Type: String.
     :param output_data: The data that you wish to upload to s3 - Type: JSON.
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: None
     """
     s3 = boto3.resource("s3", region_name="eu-west-2")
-    s3.Object(bucket_name, output_file_name).put(Body=output_data,
+
+    full_file_name = output_file_name
+    if len(run_id) > 0:
+        full_file_name = run_id + "-" + output_file_name
+
+    s3.Object(bucket_name, full_file_name).put(Body=output_data,
                                                  ContentType='application/json')
 
 
@@ -271,16 +294,22 @@ def send_sqs_message(queue_url, message, output_message_id):
     )
 
 
-def write_dataframe_to_csv(dataframe, bucket_name, filename):
+def write_dataframe_to_csv(dataframe, bucket_name, filename, run_id = ""):
     """
     This function takes a Dataframe and stores it in a specific bucket.
     :param dataframe: The Dataframe you wish to save - Type: Dataframe.
     :param bucket_name: Name of the bucket you wish to save the csv into - Type: String.
     :param filename: The name given to the CSV - Type: String.
+    :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: None
     """
     csv_buffer = StringIO()
     dataframe.to_csv(csv_buffer, sep=",", index=False)
     s3_resource = boto3.resource("s3")
+
+    full_file_name = output_file_name
+    if len(run_id) > 0:
+        full_file_name = run_id + "-" + output_file_name
+
     s3_resource.Object(bucket_name, filename).put(Body=csv_buffer.getvalue(),
                                                   ContentType='text/plain')

--- a/es_aws_functions/aws_functions.py
+++ b/es_aws_functions/aws_functions.py
@@ -162,7 +162,7 @@ def read_dataframe_from_s3(bucket_name, file_name, run_id=""):
     :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: input_file: The JSON file in S3 loaded into dataframe table - Type: DataFrame
     """
-    input_file = read_from_s3(bucket_name, file_name)
+    input_file = read_from_s3(bucket_name, file_name, run_id)
     json_content = json.loads(input_file)
     return pd.DataFrame(json_content)
 

--- a/es_aws_functions/aws_functions.py
+++ b/es_aws_functions/aws_functions.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 from es_aws_functions import exception_classes
 
 
-def delete_data(bucket_name, file_name, run_id = ""):
+def delete_data(bucket_name, file_name, run_id=""):
     """
     Deletes specified file from specified S3 bucket.
     Checks if file exists before deletion.
@@ -32,7 +32,7 @@ def delete_data(bucket_name, file_name, run_id = ""):
         return "File does not exist in specified bucket!"
 
 
-def get_data(queue_url, bucket_name, key, incoming_message_group, run_id = ""):
+def get_data(queue_url, bucket_name, key, incoming_message_group, run_id=""):
     """
     Get data function recieves a message from an sqs queue,
     extracts the bucket and filename, then uses them to get the file from s3.
@@ -75,12 +75,11 @@ def get_data(queue_url, bucket_name, key, incoming_message_group, run_id = ""):
         message = json.loads(message["Body"])
         bucket = message["bucket"]
         key = message["key"]
-        
     data = read_from_s3(bucket, key, run_id)
     return data, receipt_handle
 
 
-def get_dataframe(queue_url, bucket_name, key, incoming_message_group, run_id = ""):
+def get_dataframe(queue_url, bucket_name, key, incoming_message_group, run_id=""):
     """
     Get data function recieves a message from an sqs queue,
     extracts the bucket and filename, then uses them to get the file from s3.
@@ -106,7 +105,7 @@ def get_dataframe(queue_url, bucket_name, key, incoming_message_group, run_id = 
     :return receipt_handle: The receipt_handle of the incoming message
     (used to delete old message) - Type: String
     """
-    data, receipt_handle = get_data(queue_url, bucket_name, key, 
+    data, receipt_handle = get_data(queue_url, bucket_name, key,
                                     incoming_message_group, run_id)
     data = pd.read_json(data, dtype=False)
     return data, receipt_handle
@@ -154,7 +153,7 @@ def get_sqs_messages(sqs_queue_url, number_of_messages, incoming_message_group):
     return messages
 
 
-def read_dataframe_from_s3(bucket_name, file_name, run_id = ""):
+def read_dataframe_from_s3(bucket_name, file_name, run_id=""):
     """
     Given the name of the bucket and the filename(key), this function will
     return contents of a file. File is DataFrame format.
@@ -168,7 +167,7 @@ def read_dataframe_from_s3(bucket_name, file_name, run_id = ""):
     return pd.DataFrame(json_content)
 
 
-def read_from_s3(bucket_name, file_name, run_id = ""):
+def read_from_s3(bucket_name, file_name, run_id=""):
     """
     Given the name of the bucket and the filename(key), this function will
     return a file. File is JSON format.
@@ -189,7 +188,7 @@ def read_from_s3(bucket_name, file_name, run_id = ""):
     return input_file
 
 
-def save_data(bucket_name, file_name, data, queue_url, message_id, run_id = ""):
+def save_data(bucket_name, file_name, data, queue_url, message_id, run_id=""):
     """
     Save data function stores data in s3 and passes the bucket & filename
     onto sqs queue. SQS only supports message length of 256k, so this function
@@ -212,7 +211,7 @@ def save_data(bucket_name, file_name, data, queue_url, message_id, run_id = ""):
     send_sqs_message(queue_url, sqs_message, message_id)
 
 
-def save_to_s3(bucket_name, output_file_name, output_data, run_id = ""):
+def save_to_s3(bucket_name, output_file_name, output_data, run_id=""):
     """
     This function uploads a specified set of data to the s3 bucket under the given name.
     :param bucket_name: Name of the bucket you wish to upload too - Type: String.
@@ -228,7 +227,7 @@ def save_to_s3(bucket_name, output_file_name, output_data, run_id = ""):
         full_file_name = run_id + "-" + output_file_name
 
     s3.Object(bucket_name, full_file_name).put(Body=output_data,
-                                                 ContentType='application/json')
+                                               ContentType='application/json')
 
 
 def send_sns_message(checkpoint, sns_topic_arn, module_name):
@@ -294,12 +293,12 @@ def send_sqs_message(queue_url, message, output_message_id):
     )
 
 
-def write_dataframe_to_csv(dataframe, bucket_name, filename, run_id = ""):
+def write_dataframe_to_csv(dataframe, bucket_name, file_name, run_id=""):
     """
     This function takes a Dataframe and stores it in a specific bucket.
     :param dataframe: The Dataframe you wish to save - Type: Dataframe.
     :param bucket_name: Name of the bucket you wish to save the csv into - Type: String.
-    :param filename: The name given to the CSV - Type: String.
+    :param file_name: The name given to the CSV - Type: String.
     :param run_id: Optional, run id to be added as file name prefix - Type: String
     :return: None
     """
@@ -307,9 +306,9 @@ def write_dataframe_to_csv(dataframe, bucket_name, filename, run_id = ""):
     dataframe.to_csv(csv_buffer, sep=",", index=False)
     s3_resource = boto3.resource("s3")
 
-    full_file_name = output_file_name
+    full_file_name = file_name
     if len(run_id) > 0:
-        full_file_name = run_id + "-" + output_file_name
+        full_file_name = run_id + "-" + file_name
 
-    s3_resource.Object(bucket_name, filename).put(Body=csv_buffer.getvalue(),
-                                                  ContentType='text/plain')
+    s3_resource.Object(bucket_name, full_file_name).put(Body=csv_buffer.getvalue(),
+                                                        ContentType='text/plain')


### PR DESCRIPTION
All functions that interact with S3 files now have an optional parameter run_id, if provided it will be prefixed onto the file name to ensure uniqueness across runs.